### PR TITLE
Add EnableShorten, DisableShorten

### DIFF
--- a/lib/activerecord/simple_index_name.rb
+++ b/lib/activerecord/simple_index_name.rb
@@ -1,6 +1,8 @@
 require "active_record"
 require "activerecord/simple_index_name/version"
 require "activerecord/simple_index_name/configuration"
+require "activerecord/simple_index_name/disable_shorten"
+require "activerecord/simple_index_name/enable_shorten"
 
 module Activerecord
   module SimpleIndexName
@@ -10,6 +12,14 @@ module Activerecord
 
     def self.configure
       yield config if block_given?
+    end
+
+    def self.with_shorten(shorten)
+      Thread.current[:simple_index_name_shorten_mode] = shorten
+
+      yield if block_given?
+    ensure
+      Thread.current[:simple_index_name_shorten_mode] = nil
     end
   end
 end

--- a/lib/activerecord/simple_index_name/active_record_ext.rb
+++ b/lib/activerecord/simple_index_name/active_record_ext.rb
@@ -2,7 +2,17 @@ module ActiveRecord
   module ConnectionAdapters
     module SchemaStatements
       def index_name_with_simple(table_name, options)
-        if Activerecord::SimpleIndexName.config.auto_shorten
+        shorten_mode =
+          case Thread.current[:simple_index_name_shorten_mode]
+          when :enable
+            true
+          when :disable
+            false
+          else
+            Activerecord::SimpleIndexName.config.auto_shorten
+          end
+
+        if shorten_mode
           if Hash === options && options[:column]
             Array.wrap(options[:column]) * "_and_"
           else

--- a/lib/activerecord/simple_index_name/disable_shorten.rb
+++ b/lib/activerecord/simple_index_name/disable_shorten.rb
@@ -1,0 +1,11 @@
+module Activerecord
+  module SimpleIndexName
+    module DisableShorten
+      def exec_migration(conn, direction)
+        Activerecord::SimpleIndexName.with_shorten(:disable) do
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/activerecord/simple_index_name/enable_shorten.rb
+++ b/lib/activerecord/simple_index_name/enable_shorten.rb
@@ -1,0 +1,11 @@
+module Activerecord
+  module SimpleIndexName
+    module EnableShorten
+      def exec_migration(conn, direction)
+        Activerecord::SimpleIndexName.with_shorten(:enable) do
+          super
+        end
+      end
+    end
+  end
+end

--- a/spec/activerecord/simple_index_name/active_record_ext_spec.rb
+++ b/spec/activerecord/simple_index_name/active_record_ext_spec.rb
@@ -32,6 +32,22 @@ describe ActiveRecord::ConnectionAdapters::SchemaStatements do
       end
     end
 
+    context "When auto_shorten is either enabled or disabled" do
+      [true, false].each do |auto_shorten|
+        context "When auto_shorten is #{auto_shorten}" do
+          include_context :setup_database, auto_shorten: auto_shorten
+
+          context "When has DisableShorten in migration" do
+            it_is_asserted_by { index_name_of(:user_stocks, :article_id) == "index_user_stocks_on_article_id" }
+          end
+
+          context "When has EnableShorten in migration" do
+            it_is_asserted_by { index_name_of(:articles, :category_id) == "category_id" }
+          end
+        end
+      end
+    end
+
     def table_indexes(table)
       ActiveRecord::Base.connection.indexes(table)
     end

--- a/spec/db/migrate/0004_add_article_index_to_user_stocks.rb
+++ b/spec/db/migrate/0004_add_article_index_to_user_stocks.rb
@@ -1,0 +1,7 @@
+class AddArticleIndexToUserStocks < ActiveRecord::Migration
+  include Activerecord::SimpleIndexName::DisableShorten
+
+  def change
+    add_index :user_stocks, :article_id
+  end
+end

--- a/spec/db/migrate/0005_add_category_id_to_articles.rb
+++ b/spec/db/migrate/0005_add_category_id_to_articles.rb
@@ -1,0 +1,8 @@
+class AddCategoryIdToArticles < ActiveRecord::Migration
+  include Activerecord::SimpleIndexName::EnableShorten
+
+  def change
+    add_column :articles, :category_id, :integer
+    add_index :articles, :category_id
+  end
+end


### PR DESCRIPTION
# Overview
When `auto_shorten` is enabled, we can disable simple index name in only specified migration.
(or when `auto_shorten` is disabled, we can enable simple index name in only specified migration)

# Features
* `ActiveRecord::SimpleIndexName::EnableShorten`
  * When include `ActiveRecord::SimpleIndexName::EnableShorten` in any migration file, enable simple index name
* `ActiveRecord::SimpleIndexName::DisableShorten`
  * When include `ActiveRecord::SimpleIndexName::DisableShorten`  in any migration file, disable simple index name

# Example 1
```ruby
class AddCategoryIdToArticles < ActiveRecord::Migration
  include Activerecord::SimpleIndexName::EnableShorten

  def change
    add_column :articles, :category_id, :integer
    add_index :articles, :category_id
  end
end
```

include `ActiveRecord::SimpleIndexName::EnableShorten`, use simple index name regardless of whether `auto_shorten` is `true` or `false`

# Example 2
```ruby
class AddArticleIndexToUserStocks < ActiveRecord::Migration
  include ActiveRecord::SimpleIndexName::DisableShorten

  def change
    add_index :user_stocks, :article_id
  end
end
```

include `ActiveRecord::SimpleIndexName::DisableShorten`, don't use simple index name regardless of whether `auto_shorten` is `true` or `false`

#11

