### PR TITLE
Support activerecord 5.0.0.beta2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /spec/reports/
 /tmp/
 log/
+gemfiles/*.lock
+gemfiles/vendor/bundle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
 - 2.1
-- 2.2
+- 2.2.4
 - 2.3.0
 - ruby-head
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,7 @@ notifications:
 matrix:
   allow_failures:
   - rvm: ruby-head
-
+  exclude:
+  # NOTE: activesupport 5.x requires Ruby version >= 2.2.2
+  - rvm: 2.1
+    gemfile: gemfiles/rails_5_0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ gemfile:
 - gemfiles/rails_4_0.gemfile
 - gemfiles/rails_4_1.gemfile
 - gemfiles/rails_4_2.gemfile
+- gemfiles/rails_5_0.gemfile
 cache: bundler
 sudo: false
 before_install: gem install bundler -v 1.10.6
@@ -26,3 +27,4 @@ notifications:
 matrix:
   allow_failures:
   - rvm: ruby-head
+

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 5.0.0.beta2"
+
+gemspec path: '../'

--- a/lib/active_record/simple_index_name/active_record_ext.rb
+++ b/lib/active_record/simple_index_name/active_record_ext.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
-  module ConnectionAdapters
-    module SchemaStatements
-      def index_name_with_simple(table_name, options)
+  module SimpleIndexName
+    module ActiveRecordExt
+      def index_name(table_name, options)
         shorten_mode =
           case Thread.current[:simple_index_name_shorten_mode]
           when :enable
@@ -16,14 +16,16 @@ module ActiveRecord
           if Hash === options && options[:column]
             Array.wrap(options[:column]) * "_and_"
           else
-            index_name_without_simple(table_name, options)
+            super
           end
         else
-          index_name_without_simple(table_name, options)
+          super
         end
       end
-
-      alias_method_chain :index_name, :simple
     end
   end
+end
+
+ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
+  prepend ActiveRecord::SimpleIndexName::ActiveRecordExt
 end

--- a/lib/active_record/simple_index_name/active_record_ext.rb
+++ b/lib/active_record/simple_index_name/active_record_ext.rb
@@ -12,12 +12,8 @@ module ActiveRecord
             ActiveRecord::SimpleIndexName.config.auto_shorten
           end
 
-        if shorten_mode
-          if Hash === options && options[:column]
-            Array.wrap(options[:column]) * "_and_"
-          else
-            super
-          end
+        if shorten_mode && Hash === options && options[:column]
+          Array.wrap(options[:column]) * "_and_"
         else
           super
         end


### PR DESCRIPTION
# TODO
* [x] fix DEPRECATION WARNING
  * `DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from <module:SchemaStatements> at /home/travis/build/sue445/activerecord-simple_index_name/lib/active_record/simple_index_name/active_record_ext.rb:26)`