### PR TITLE
Fix DEPRECATION warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,10 @@ if ENV["CI"]
   require "coveralls"
   require "codeclimate-test-reporter"
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     CodeClimate::TestReporter::Formatter,
     Coveralls::SimpleCov::Formatter
-  ]
+  ])
   SimpleCov.start do
     %w(spec).each do |ignore_path|
       add_filter(ignore_path)


### PR DESCRIPTION
```
/Users/sue445/dev/workspace/github.com/sue445/activerecord-simple_index_name/spec/spec_helper.rb:6:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
```