### PR TITLE
Add development dependency to byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.0")
-  # NOTE: byebug 9.1.0+ requires ruby 2.2.0+
-  gem "byebug", "< 9.1.0"
+  group :development do
+    # NOTE: byebug 9.1.0+ requires ruby 2.2.0+
+    gem "byebug", "< 9.1.0", group: :test
+  end
 end


### PR DESCRIPTION
`byebug` are used in only test code, but gemnasium regards that used in production code

https://gemnasium.com/sue445/activerecord-simple_index_name

![image](https://user-images.githubusercontent.com/608755/34967042-51cace1a-faa3-11e7-8f1f-4e80403f37bb.png)
