### PR TITLE
Drop support for Ruby 2.2 and Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2.2
   - 2.3
   - 2.4
   - 2.5
   - 2.6
   - ruby-head
 gemfile:
-  - gemfiles/rails_4_0.gemfile
-  - gemfiles/rails_4_1.gemfile
-  - gemfiles/rails_4_2.gemfile
   - gemfiles/rails_5_0.gemfile
   - gemfiles/rails_5_1.gemfile
   - gemfiles/rails_5_2.gemfile
@@ -42,15 +37,6 @@ matrix:
       env: RUBYOPT="--jit"
     - rvm: ruby-head
       env: RUBYOPT="--jit"
-
-  exclude:
-    # NOTE: activesupport 5.x requires Ruby version >= 2.2.2
-    - rvm: 2.1
-      gemfile: gemfiles/rails_5_0.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails_5_1.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails_5_2.gemfile
 
 env:
   global:

--- a/activerecord-simple_index_name.gemspec
+++ b/activerecord-simple_index_name.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord"
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activerecord", ">= 5.0.0"
+  spec.add_dependency "activesupport", ">= 5.0.0"
 
   spec.add_development_dependency "activerecord-compatible_legacy_migration"
   spec.add_development_dependency "bundler"

--- a/gemfiles/rails_4_0.gemfile
+++ b/gemfiles/rails_4_0.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 4.0.0"
-
-gemspec path: '../'

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 4.1.0"
-
-gemspec path: '../'

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 4.2.0"
-
-gemspec path: '../'

--- a/spec/activerecord/simple_index_name/active_record_ext_spec.rb
+++ b/spec/activerecord/simple_index_name/active_record_ext_spec.rb
@@ -62,7 +62,7 @@ describe ActiveRecord::ConnectionAdapters::SchemaStatements do
 
     def index_name_of(table, columns)
       columns = Array.wrap(columns).map(&:to_s)
-      table_indexes(table.to_s).find { |index| index.columns == columns }.try(:name)
+      table_indexes(table.to_s).find { |index| index.columns == columns }&.name
     end
   end
 end


### PR DESCRIPTION
Now, the build time has become very very long...

about 1 hour :weary:
https://travis-ci.org/sue445/activerecord-simple_index_name/builds/475075295

So I want to drop support old ruby and rails versions.