### PR TITLE
Remove activerecord-compatible_legacy_migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in activerecord-simple_index_name.gemspec
 gemspec
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.0")
-  group :development do
-    # NOTE: byebug 9.1.0+ requires ruby 2.2.0+
-    gem "byebug", "< 9.1.0", group: :test
-  end
-end

--- a/activerecord-simple_index_name.gemspec
+++ b/activerecord-simple_index_name.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 5.0.0"
   spec.add_dependency "activesupport", ">= 5.0.0"
 
-  spec.add_development_dependency "activerecord-compatible_legacy_migration"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "pry-byebug"

--- a/spec/db/migrate/0001_create_user_stocks.rb
+++ b/spec/db/migrate/0001_create_user_stocks.rb
@@ -1,4 +1,4 @@
-class CreateUserStocks < ActiveRecord::CompatibleLegacyMigration.migration_class
+class CreateUserStocks < ActiveRecord::Migration[4.2]
   def change
     create_table :user_stocks do |t|
       t.integer :user_id,    null: false

--- a/spec/db/migrate/0002_create_articles.rb
+++ b/spec/db/migrate/0002_create_articles.rb
@@ -1,4 +1,4 @@
-class CreateArticles < ActiveRecord::CompatibleLegacyMigration.migration_class
+class CreateArticles < ActiveRecord::Migration[4.2]
   def change
     create_table :articles do |t|
       t.integer :user_id, null: false

--- a/spec/db/migrate/0003_create_comments.rb
+++ b/spec/db/migrate/0003_create_comments.rb
@@ -1,4 +1,4 @@
-class CreateComments < ActiveRecord::CompatibleLegacyMigration.migration_class
+class CreateComments < ActiveRecord::Migration[4.2]
   def change
     create_table :comments do |t|
       t.integer :user_id, null: false

--- a/spec/db/migrate/0004_add_article_index_to_user_stocks.rb
+++ b/spec/db/migrate/0004_add_article_index_to_user_stocks.rb
@@ -1,4 +1,4 @@
-class AddArticleIndexToUserStocks < ActiveRecord::CompatibleLegacyMigration.migration_class
+class AddArticleIndexToUserStocks < ActiveRecord::Migration[4.2]
   include ActiveRecord::SimpleIndexName::DisableShorten
 
   def change

--- a/spec/db/migrate/0005_add_category_id_to_articles.rb
+++ b/spec/db/migrate/0005_add_category_id_to_articles.rb
@@ -1,4 +1,4 @@
-class AddCategoryIdToArticles < ActiveRecord::CompatibleLegacyMigration.migration_class
+class AddCategoryIdToArticles < ActiveRecord::Migration[4.2]
   include ActiveRecord::SimpleIndexName::EnableShorten
 
   def change

--- a/spec/db/migrate/0006_create_old_table.rb
+++ b/spec/db/migrate/0006_create_old_table.rb
@@ -1,4 +1,4 @@
-class CreateOldTable < ActiveRecord::CompatibleLegacyMigration.migration_class
+class CreateOldTable < ActiveRecord::Migration[4.2]
   def change
     create_table :old_table do |t|
       t.string :anonymous_name, null: false

--- a/spec/db/migrate/0007_rename_old_table_to_new_table.rb
+++ b/spec/db/migrate/0007_rename_old_table_to_new_table.rb
@@ -1,4 +1,4 @@
-class RenameOldTableToNewTable < ActiveRecord::CompatibleLegacyMigration.migration_class
+class RenameOldTableToNewTable < ActiveRecord::Migration[4.2]
   def change
     rename_table :old_table, :new_table
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,6 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require "active_record/simple_index_name"
 require "rspec-power_assert"
 require "pry"
-require "activerecord-compatible_legacy_migration"
 
 require_relative "./db/setup"
 


### PR DESCRIPTION
When only AR 5.0+, activerecord-compatible legacy migration is unnecessary