### PR TITLE
Fix CI on activerecord v6.0.0.rc2

### DIFF
--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "~> 6.0.0.rc1"
+gem "rails", "~> 6.0.0.rc2"
 
 # c.f. https://github.com/rails/rails/blob/v6.0.0.rc1/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13
 gem "sqlite3", "~> 1.4"

--- a/spec/db/setup.rb
+++ b/spec/db/setup.rb
@@ -22,7 +22,9 @@ def up_migrate
   ActiveRecord::Tasks::DatabaseTasks.create(configuration)
 
   # db:migrate
-  if ActiveRecord.version >= Gem::Version.create("5.2.0")
+  if ActiveRecord.version >= Gem::Version.create("6.0.0.rc2")
+    ActiveRecord::MigrationContext.new(migrate_dir, ActiveRecord::SchemaMigration).up
+  elsif ActiveRecord.version >= Gem::Version.create("5.2.0")
     ActiveRecord::MigrationContext.new(migrate_dir).up
   else
     ActiveRecord::Migrator.up(migrate_dir)
@@ -31,7 +33,9 @@ end
 
 def down_migrate
   # db:down
-  if ActiveRecord.version >= Gem::Version.create("5.2.0")
+  if ActiveRecord.version >= Gem::Version.create("6.0.0.rc2")
+    ActiveRecord::MigrationContext.new(migrate_dir, ActiveRecord::SchemaMigration).down
+  elsif ActiveRecord.version >= Gem::Version.create("5.2.0")
     ActiveRecord::MigrationContext.new(migrate_dir).down
   else
     ActiveRecord::Migrator.down(migrate_dir)


### PR DESCRIPTION
```
     1.1) Failure/Error: ActiveRecord::MigrationContext.new(migrate_dir).up

          ArgumentError:
            wrong number of arguments (given 1, expected 2)
          # ./gemfiles/vendor/bundle/ruby/2.6.0/gems/activerecord-6.0.0.rc2/lib/active_record/migration.rb:1020:in `initialize'
          # ./spec/db/setup.rb:26:in `new'
          # ./spec/db/setup.rb:26:in `up_migrate'
          # ./spec/support/contexts/setup_databse.rb:4:in `block (2 levels) in <top (required)>'
```

Close #55