### PR TITLE
Fix support activerecord 7.1

### DIFF
--- a/lib/active_record/simple_index_name/active_record_ext_7_1.rb
+++ b/lib/active_record/simple_index_name/active_record_ext_7_1.rb
@@ -36,6 +36,9 @@ ActiveRecord::ConnectionAdapters::SchemaStatements.class_eval do
   prepend ActiveRecord::SimpleIndexName::ActiveRecordExt_7_1::SchemaStatements
 end
 
-ActiveRecord::Migration::Compatibility::V7_0::LegacyIndexName.module_eval do
+ActiveRecord::Migration::Compatibility::V7_0.class_eval do
+  prepend ActiveRecord::SimpleIndexName::ActiveRecordExt_7_1::V7_0
+end
+ActiveRecord::Migration::Compatibility::V7_0::TableDefinition.module_eval do
   prepend ActiveRecord::SimpleIndexName::ActiveRecordExt_7_1::V7_0
 end

--- a/lib/active_record/simple_index_name/active_record_ext_7_1.rb
+++ b/lib/active_record/simple_index_name/active_record_ext_7_1.rb
@@ -36,6 +36,6 @@ ActiveRecord::ConnectionAdapters::SchemaStatements.class_eval do
   prepend ActiveRecord::SimpleIndexName::ActiveRecordExt_7_1::SchemaStatements
 end
 
-ActiveRecord::Migration::Compatibility::V7_0.class_eval do
+ActiveRecord::Migration::Compatibility::V7_0::LegacyIndexName.module_eval do
   prepend ActiveRecord::SimpleIndexName::ActiveRecordExt_7_1::V7_0
 end

--- a/spec/activerecord/simple_index_name/active_record_ext_spec.rb
+++ b/spec/activerecord/simple_index_name/active_record_ext_spec.rb
@@ -18,6 +18,10 @@ describe ActiveRecord::ConnectionAdapters::SchemaStatements do
       context "When index name of renamed table" do
         it { expect(index_name_of(:new_table, :anonymous_name)).to eq "anonymous_name" }
       end
+
+      context "When add index in create_table" do
+        it { expect(index_name_of(:user_stocks, :foo_id)).to eq "foo_id" }
+      end
     end
 
     context "When auto_shorten is disabled" do
@@ -37,6 +41,10 @@ describe ActiveRecord::ConnectionAdapters::SchemaStatements do
 
       context "When index name of renamed table" do
         it { expect(index_name_of(:new_table, :anonymous_name)).to eq "index_new_table_on_anonymous_name" }
+      end
+
+      context "When add index in create_table" do
+        it { expect(index_name_of(:user_stocks, :foo_id)).to eq "index_user_stocks_on_foo_id" }
       end
     end
 

--- a/spec/db/migrate/0001_create_user_stocks.rb
+++ b/spec/db/migrate/0001_create_user_stocks.rb
@@ -3,7 +3,9 @@ class CreateUserStocks < ActiveRecord::Migration[4.2]
     create_table :user_stocks do |t|
       t.integer :user_id,    null: false
       t.integer :article_id, null: false
+      t.integer :foo_id
       t.timestamps null: false
+      t.index :foo_id
     end
     add_index :user_stocks, [:user_id, :article_id]
   end


### PR DESCRIPTION
The current implementation does not support defining index in `create_table`.
AR 7.1 includes LegacyIndexName in two places.

* https://github.com/rails/rails/blob/v7.1.3.2/activerecord/lib/active_record/migration/compatibility.rb#L66
* https://github.com/rails/rails/blob/v7.1.3.2/activerecord/lib/active_record/migration/compatibility.rb#L88